### PR TITLE
Add outputs for Terraform EKS, VPC, RDS, SNS, and SQS modules

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,85 @@
+# EKS Outputs
+output "cluster_name" {
+  description = "Name of the EKS cluster"
+  value       = module.eks_instance.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint of the EKS cluster"
+  value       = module.eks_instance.cluster_endpoint
+}
+
+output "cluster_ca_certificate" {
+  description = "Base64 encoded certificate data required to communicate with the cluster"
+  value       = module.eks_instance.cluster_ca_certificate
+}
+
+output "cluster_token" {
+  description = "Token for EKS cluster authentication"
+  value       = module.eks_instance.cluster_token
+  sensitive   = true
+}
+
+# VPC Outputs
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.eks_instance.vpc_id
+}
+
+output "vpc_cidr" {
+  description = "CIDR block of the VPC"
+  value       = module.eks_instance.vpc_cidr
+}
+
+output "subnet_ids" {
+  description = "List of subnet IDs"
+  value       = module.eks_instance.subnet_ids
+}
+
+# RDS Outputs
+output "rds_postgres_kitchen_endpoint" {
+  description = "DNS endpoint of the kitchen RDS instance"
+  value       = module.rds_instance.rds_postgres_kitchen_endpoint
+}
+
+output "rds_postgres_kitchen_db_name" {
+  description = "Database name of the kitchen RDS instance"
+  value       = module.rds_instance.rds_postgres_kitchen_db_name
+}
+
+output "rds_postgres_order_endpoint" {
+  description = "DNS endpoint of the order RDS instance"
+  value       = module.rds_instance.rds_postgres_order_endpoint
+}
+
+output "rds_postgres_order_db_name" {
+  description = "Database name of the order RDS instance"
+  value       = module.rds_instance.rds_postgres_order_db_name
+}
+
+output "rds_username" {
+  description = "Shared username for the RDS instances"
+  value       = module.rds_instance.rds_username
+}
+
+# SNS Outputs
+output "sns_topic_arn" {
+  description = "ARN of the created SNS topic"
+  value       = module.sns_instance.sns_topic_arn
+}
+
+output "sns_topic_name" {
+  description = "Name of the created SNS topic"
+  value       = module.sns_instance.sns_topic_name
+}
+
+# SQS Outputs
+output "sqs_queue_urls" {
+  description = "Map of SQS queue names to their URLs"
+  value       = module.sqs_instance.sqs_queue_urls
+}
+
+output "sqs_queue_arns" {
+  description = "Map of SQS queue names to their ARNs"
+  value       = module.sqs_instance.sqs_queue_arns
+}


### PR DESCRIPTION
This pull request adds outputs for the Terraform modules related to EKS, VPC, RDS, SNS, and SQS. These outputs provide access to key module resources for use in downstream configurations or integrations