### PR TITLE
Remove unused MongoDB Atlas environment variables

### DIFF
--- a/.github/workflows/cd-create-aws-tf.yaml
+++ b/.github/workflows/cd-create-aws-tf.yaml
@@ -47,10 +47,6 @@ jobs:
       - name: Terraform Plan
         id: plan
         env:
-          TF_VAR_mongodb_atlas_public_key: ${{ secrets.MONGODB_ATLAS_PUBLIC_KEY }}
-          TF_VAR_mongodb_atlas_private_key: ${{ secrets.MONGODB_ATLAS_PRIVATE_KEY }}
-          TF_VAR_mongodb_atlas_org_id: ${{ secrets.MONGODB_ATLAS_ORG_ID }}
-          TF_VAR_mongodb_password: ${{ secrets.MONGODB_PASSWORD }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_rds_db_password: ${{ secrets.RDS_DB_PASSWORD }}
           TF_VAR_rds_db_username: ${{ secrets.RDS_DB_USERNAME }}
@@ -59,10 +55,6 @@ jobs:
       - name: Terraform Apply
         id: apply
         env:
-          TF_VAR_mongodb_atlas_public_key: ${{ secrets.MONGODB_ATLAS_PUBLIC_KEY }}
-          TF_VAR_mongodb_atlas_private_key: ${{ secrets.MONGODB_ATLAS_PRIVATE_KEY }}
-          TF_VAR_mongodb_atlas_org_id: ${{ secrets.MONGODB_ATLAS_ORG_ID }}
-          TF_VAR_mongodb_password: ${{ secrets.MONGODB_PASSWORD }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_rds_db_password: ${{ secrets.RDS_DB_PASSWORD }}
           TF_VAR_rds_db_username: ${{ secrets.RDS_DB_USERNAME }}


### PR DESCRIPTION
The pull request removes unused MongoDB Atlas-related environment variables from the Continuous Deployment (CD) pipeline workflows. This change simplifies and optimizes the workflow configuration by eliminating unnecessary variables