### PR TITLE
Simplify DynamoDB table names in Terraform modules

### DIFF
--- a/modules/dynamodb_customer/main.tf
+++ b/modules/dynamodb_customer/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 # DynamoDB Table for Customer Service
 resource "aws_dynamodb_table" "customer_service" {
-  name           = "${var.project_name}-${var.environment}-customers"
+  name           = "customers"
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null
   write_capacity = var.billing_mode == "PROVISIONED" ? var.write_capacity : null

--- a/modules/dynamodb_payments/main.tf
+++ b/modules/dynamodb_payments/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 # DynamoDB Table for Payment Service
 resource "aws_dynamodb_table" "payment_service" {
-  name           = "${var.project_name}-${var.environment}-payments"
+  name           = "payments"
   billing_mode   = var.billing_mode
   read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null
   write_capacity = var.billing_mode == "PROVISIONED" ? var.write_capacity : null


### PR DESCRIPTION
Updated `dynamodb_customer` and `dynamodb_payments` modules to simplify DynamoDB table naming conventions. This will enhance clarity and maintainability for future